### PR TITLE
Changed menu 'edit' to 'rename'

### DIFF
--- a/resources/views/menus/browse.blade.php
+++ b/resources/views/menus/browse.blade.php
@@ -51,7 +51,7 @@
                                         @endcan
                                         @can('edit', $data)
                                             <a href="{{ route('voyager.'.$dataType->slug.'.edit', $data->{$data->getKeyName()}) }}" class="btn btn-sm btn-primary pull-right edit">
-                                                <i class="voyager-edit"></i> {{ __('voyager.generic.edit') }}
+                                                <i class="voyager-edit"></i> {{ __('voyager.generic.rename') }}
                                             </a>
                                         @endcan
                                         @can('edit', $data)


### PR DESCRIPTION
Presently, 'editing' a menu is actually simply renaming it. The 'Builder' button is the actual edit action, while the current 'edit' button is simply doing rename. Just a nomenclature issue.